### PR TITLE
fixed plot error causing matplotlib axvline to fail with time ranges

### DIFF
--- a/causalimpact/analysis.py
+++ b/causalimpact/analysis.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from pandas._libs.tslibs.timestamps import Timestamp
 from pandas.api.types import is_list_like
 
 from causalimpact.misc import (
@@ -623,7 +624,11 @@ class CausalImpact(object):
         plt.figure(figsize=(15, 12))
 
         data_inter = self.params["pre_period"][1]
+        if isinstance(data_inter, pd.DatetimeIndex):
+            data_inter = pd.Timestamp(data_inter)
+
         inferences = self.inferences.iloc[1:, :]
+
         # Observation and regression components
         if "original" in panels:
             ax1 = plt.subplot(3, 1, 1)


### PR DESCRIPTION
When instanciating `CausalImpact` with date ranges for pre/post periods, the method `plot` causes matplotlib to fail:  "ConversionError: Failed to convert value(s) to axis units".

This is because of matplotlib expects Timestamps on the horizontal axis of the plot created using a DatetimeIndex (self.data.index) and fails to convert the provided String argument (data_inter).

Here's a minimal code to reproduce this:
```
import numpy as np
import pandas as pd

self_data_index = pd.date_range('2021-01-01', '2021-01-31')
data_inter = '2021-01-15'

plt.plot(self_data_index, np.zeros(self_data_index.shape[0]))

plt.axvline(data_inter) # Fails
>>> ConversionError: Failed to convert value(s) to axis units: '2021-01-15'

plt.axvline(pd.Timestamp(data_inter)) # Works
>>> Works.
```