### PR TITLE
Fixing documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install git+ssh://github.com/jamalsenouci/causalimpact.git
 
 #### Getting started
 
-[Documentation and examples](http://jamalsenouci.github.io/projects/causalimpact.html)
+[Documentation and examples](https://mybinder.org/v2/gh/jamalsenouci/causalimpact/HEAD?filepath=GettingStarted.ipynb)
 
 #### Further resources
 


### PR DESCRIPTION
The old link was pointing to a 404 error page.