### PR TITLE
Fix outdated pandas function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,4 @@
 # Contributors
 
 - Jamal Senouci <jamalsenouci@gmail.com>
+- Alex Roy

--- a/src/causalimpact/analysis.py
+++ b/src/causalimpact/analysis.py
@@ -1,7 +1,7 @@
 import textwrap
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_list_like
+from pandas.api.types import is_list_like, is_datetime64_dtype
 
 from causalimpact.misc import standardize_all_variables, df_print, get_matplotlib
 from causalimpact.model import construct_model, model_fit
@@ -181,11 +181,11 @@ class CausalImpact:
         if isinstance(data.index, pd.core.indexes.datetimes.DatetimeIndex):
             pre_period = [pd.to_datetime(date) for date in pre_period]
             post_period = [pd.to_datetime(date) for date in post_period]
-            pd.core.dtypes.common.is_datetime_or_timedelta_dtype(pre_period)
+            is_datetime64_dtype(pre_period)
         # if index is not datetime then error if datetime pre and post is passed
-        elif pd.core.dtypes.common.is_datetime_or_timedelta_dtype(
+        elif is_datetime64_dtype(
             pd.Series(pre_period)
-        ) or pd.core.dtypes.common.is_datetime_or_timedelta_dtype(
+        ) or is_datetime64_dtype(
             pd.Series(post_period)
         ):
             raise ValueError(


### PR DESCRIPTION
As per issue #48, `is_datetime_or_timedelta_dtype` no longer exists in the pandas module.

[`pandas.api.types.is_datetime64_dtype`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.api.types.is_datetime64_dtype.html#pandas-api-types-is-datetime64-dtype) seems to achieve the desired result.