### PR TITLE
Fix the report summary when p>alpha 

### DIFF
--- a/src/causalimpact/analysis.py
+++ b/src/causalimpact/analysis.py
@@ -695,8 +695,7 @@ class CausalImpact:
         else:
             stmt5 = textwrap.dedent(
                 """The probability of obtaining this effect by
-                chance is large (Bayesian one-sided tail-area
-                probability {p}). This means the effect may
+                chance is p = {p}. This means the effect may
                 be spurious and would generally not be considered
                 statistically significant.""".format(p=np.round(p_value, 3)
                 )


### PR DESCRIPTION
### Issue
At the moment, the report summary doesn't render properly when p>alpha (statistically insignificant), as shown below.

![Screenshot 2024-03-20 at 10 43 05 AM](https://github.com/jamalsenouci/causalimpact/assets/19767136/f84dc9c8-706c-41f1-bd10-2d2834f55ff4)

This is caused by the code below

![Screenshot 2024-03-20 at 10 46 21 AM](https://github.com/jamalsenouci/causalimpact/assets/19767136/21a24208-8d5d-41f2-bc0a-87dec19eaac2)

### Fix
This is easily fixed by passing the p value following the way for p<alpha.

### Test
It's generating the correct report.
![Screenshot 2024-03-20 at 10 49 22 AM](https://github.com/jamalsenouci/causalimpact/assets/19767136/d5a268bd-6a00-4528-8507-2cd01e521bd1)
